### PR TITLE
fix alpha mask shader

### DIFF
--- a/Source/Stage3D/Away3D/Libraries/Away3D/src/away3d/materials/methods/AlphaMaskMethod.as
+++ b/Source/Stage3D/Away3D/Libraries/Away3D/src/away3d/materials/methods/AlphaMaskMethod.as
@@ -89,7 +89,7 @@ package away3d.materials.methods
 			vo.texturesIndex = textureReg.index;
 			
 			return getTex2DSampleCode(vo, temp, textureReg, _texture, uvReg) +
-				"mul " + targetReg + ", " + targetReg + ", " + temp + ".x\n";
+				"mul " + targetReg + ".w" + ", " + targetReg + ".w" + ", " + temp + ".x\n";
 		}
 	}
 }


### PR DESCRIPTION
The shader changes color of half-transparent pixels. It was fixed to multiply only alpha values.
![exmpl](https://cloud.githubusercontent.com/assets/1625057/16133609/9398a924-3421-11e6-8eb0-5cc9c5ae6231.png)
![exmpl2](https://cloud.githubusercontent.com/assets/1625057/16133972/5f478e22-3423-11e6-8a90-f36e634b8785.png)
